### PR TITLE
Universal Sudoku Board UI in HTML

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,6 +79,7 @@ When the user suggests implementing Time Attack mode, ask them if they should up
   and familiarise yourself with the context, before making any changes
 
 ### Theoretical Concepts
+- No Repeated Logic, Code, HTML Templates, Constants and CSS Attribute Styles. **Strictly** Enforce DRY Principle.
 - Composition for unrelated functionalities - Inheritance for models with similar base logic
 - Prefer pure functions or static class methods - stateful class methods can be impure
 - Singleton objects must be instantiated and exported as default. Also export the singleton class
@@ -86,7 +87,22 @@ When the user suggests implementing Time Attack mode, ask them if they should up
 - Do not initialise class properties before constructor - do it in the constructor. Only type declarations allowed before.
 - For storing hashable objects, prefer `Map` or `Set` over arrays for runtime performance
 
+### Stylistic
+- No single line returns of conditionals and functions (if, switch etc). You must expand them with braces.
+  However, Anonymous functions can be single line (But if there any conditionals INSIDE, all must be expanded to multi line)
+
 ### Documentation Style
+
+#### Angular
+- Styles and html templates cannot be embedded within Typescript component files.
+  Store them in separate html and scss files instead in the same directory,
+  and reference them with `templateUrl` and `styleUrl`.
+- Use updated Angular directives over deprecated syntax if possible.
+
+#### CSS
+- No single line CSS rules within css files. Every style attribute must be in a different line.
+- Inline CSS is strongly discouraged, except for test or demo files that are meant to be temporary.
+- For inline CSS, single line styles are allowed if there are a relatively small number of short attributes.
 
 #### JSDoc
 - Use JSDoc comments for functions, classes, methods with complex logic.

--- a/docs/client/core/Board.md
+++ b/docs/client/core/Board.md
@@ -1,0 +1,103 @@
+# Board (Client)
+
+The Board layer is composed of two parts working together:
+
+- BoardModelComponent (`src/client/app/components/board/board.component.ts`)
+- ClientBoardModel (`src/client/models/Board.ts`) extending the shared `BaseBoardModel`
+
+It renders a 9×9 Sudoku grid as a semantic CSS grid, manages selection, and orchestrates pending/confirm/reject flows through the model. 
+Styling is handled via CSS variables for per-edge borders to achieve classic 3×3 thick separators.
+
+See also:
+- Cell docs: `docs/client/core/Cell.md`
+- Networking & pipelines: `docs/pipeline/README.md`
+
+## Composition & Data Flow
+
+- BoardModelComponent creates and owns a `ClientBoardModel` instance.
+- The template iterates a flat index list 0..80 and renders one `app-sudoku-cell` per index:
+  - Supplies a `ClientCellModel` from `model.board[i]` via the `cell(i)` accessor.
+  - Passes the numeric `index`.
+  - Listens for the cell `(selected)` output and updates board selection.
+- The model exposes methods to set/confirm/reject pending cell values and computes board-wide progress/cooldowns via the shared base class.
+
+### Rendering
+
+- 9×9 grid using CSS Grid in `board.component.scss`.
+- Outer border is a thick black frame; 3×3 sub-grid separators are produced using nth-child selectors that set per-edge CSS variables consumed by cell styles.
+- Cell components render their own content (value/pending/notes) and pick up the border variables.
+
+### Selection
+
+- Board tracks a `selected` signal (index | null).
+- When a child cell emits `(selected)` with its index:
+  - Board updates `selected` and emits `selectedIndexChange`.
+  - Board iterates `@ViewChildren(SudokuCellComponent)` to mark only the selected child as `isSelected` and deselect the rest.
+- The selected cell gets a visual outline via a host-bound `.selected` class in the cell component.
+
+### Initialization & Seeding
+
+- On init, if `@Input() puzzle` has 81 entries, the board seeds with those values as fixed cells (non-zero become fixed).
+- If no puzzle is provided, the board seeds 81 empty (0, not fixed) cells so that every child always receives a defined model.
+- The `cell(i)` accessor is defensive and lazily creates a default empty cell if needed.
+
+### Pending / Confirm / Reject
+
+Board methods delegate to `ClientBoardModel`:
+
+- `setPendingSelected(value: number, time?: number)`
+  - Validates and sets `pendingValue` on the selected cell model.
+  - Updates `pendingGlobalCooldownEnd` on success.
+- `confirmSelected(time?: number)`
+  - Confirms a pending value on the selected cell.
+  - Updates global cooldown and clears pending global state.
+- `rejectSelected()`
+  - Rejects the selected cell’s pending changes and clears global pending.
+
+These methods combine with server-side validation/confirmation in real gameplay as described in `docs/pipeline/PacketIO.md` and `docs/pipeline/Actions.md`.
+
+### Accessibility
+
+- The board container includes `role="grid"` and `aria-rowcount="9"`/`aria-colcount="9"`.
+- Cells are buttons, making them keyboard-focusable and discoverable by screen readers with minimal extra work.
+
+## Minimal Usage
+
+```html
+<app-sudoku-board-model [puzzle]="puzzle" (selectedIndexChange)="onSelect($event)"></app-sudoku-board-model>
+```
+
+```ts
+// Component TS
+puzzle: number[] = [... 81 entries ...];
+
+onSelect(i: number) {
+  // update UI, controls, etc.
+}
+```
+
+## Key APIs
+
+- BoardModelComponent
+  - Inputs: `puzzle: ReadonlyArray<number>`
+  - Outputs: `selectedIndexChange: EventEmitter<number>`
+  - Methods for gameplay wiring:
+    - `setPendingSelected(value: number, time?: number): boolean`
+    - `confirmSelected(time?: number): boolean`
+    - `rejectSelected(): void`
+
+- ClientBoardModel (extends shared BaseBoardModel)
+  - `setPendingCell(cellIndex: number, value: number, time?: number): boolean`
+  - `confirmCellSet(cellIndex: number, value: number, time?: number): boolean`
+  - `rejectCellSet(cellIndex: number): void`
+  - `getDisplayGlobalCooldownEnd(): number`
+  - `hasPendingChanges(): boolean`
+
+## Internals & Links
+
+- Component: `src/client/app/components/board/board.component.ts`
+- Template: `src/client/app/components/board/board.component.html`
+- Styles: `src/client/app/components/board/board.component.scss`
+- Model (client): `src/client/models/Board.ts`
+- Model (shared base): `src/shared/models/Board.ts`
+- Cell pair: `docs/client/core/Cell.md`

--- a/docs/client/core/Board.md
+++ b/docs/client/core/Board.md
@@ -16,7 +16,7 @@ See also:
 
 - BoardModelComponent creates and owns a `ClientBoardModel` instance.
 - The template iterates a flat index list 0..80 and renders one `app-sudoku-cell` per index:
-  - Supplies a `ClientCellModel` from `model.board[i]` via the `cell(i)` accessor.
+  - Supplies a `ClientCellModel` from `model.board[i]` via the `getCellModel(i)` accessor.
   - Passes the numeric `index`.
   - Listens for the cell `(selected)` output and updates board selection.
 - The model exposes methods to set/confirm/reject pending cell values and computes board-wide progress/cooldowns via the shared base class.
@@ -32,14 +32,14 @@ See also:
 - Board tracks a `selected` signal (index | null).
 - When a child cell emits `(selected)` with its index:
   - Board updates `selected` and emits `selectedIndexChange`.
-  - Board iterates `@ViewChildren(SudokuCellComponent)` to mark only the selected child as `isSelected` and deselect the rest.
-- The selected cell gets a visual outline via a host-bound `.selected` class in the cell component.
+  - The template applies `[class.selected]="selected() === i"` on each `app-sudoku-cell` so selection is purely declarative (no direct access to child instances).
+- The selected cell gets a visual outline via the `.selected` class applied by the parent binding.
 
 ### Initialization & Seeding
 
-- On init, if `@Input() puzzle` has 81 entries, the board seeds with those values as fixed cells (non-zero become fixed).
-- If no puzzle is provided, the board seeds 81 empty (0, not fixed) cells so that every child always receives a defined model.
-- The `cell(i)` accessor is defensive and lazily creates a default empty cell if needed.
+- The `@Input() puzzle` uses a setter: when it receives 81 entries, the board seeds with those values as fixed cells (non-zero become fixed).
+- If no puzzle is provided, `ngOnInit` seeds 81 empty (0, not fixed) cells so that every child always receives a defined model.
+- The `getCellModel(i)` accessor is defensive and lazily creates a default empty cell if needed.
 
 ### Pending / Confirm / Reject
 

--- a/docs/client/core/Cell.md
+++ b/docs/client/core/Cell.md
@@ -1,0 +1,86 @@
+# Cell (Client)
+
+The Cell layer is composed of:
+
+- SudokuCellComponent (`src/client/app/components/cell/cell.component.ts`)
+- ClientCellModel (`src/client/models/Cell.ts`) extending the shared `BaseCellModel`
+
+It renders a single Sudoku cell and exposes events for selection. The client model supports optimistic updates via a small pending state.
+
+See also:
+- Board docs: `docs/client/core/Board.md`
+- Shared models: `src/shared/models/Cell.ts`
+
+## Composition & Data Flow
+
+- `SudokuCellComponent` receives two inputs:
+  - `model: ClientCellModel` (required)
+  - `index: number`
+- Emits `selected: EventEmitter<number>` when clicked.
+- HostBinding `class.selected` reflects visual selection controlled by the Board.
+
+### Rendering Logic
+
+Template logic chooses one of three modes:
+
+1) Notes mode (3×3 mini-grid)
+   - Shown when `model.value === 0` and `model.notes?.length > 0`.
+   - Displays digits 1–9 based on `notes` membership.
+
+2) Pending mode
+   - When `model.hasPending()` is true and `pendingValue` is present.
+   - Shows the pending value with a `.pending` style.
+
+3) Value mode
+   - Fallback: shows `model.getDisplayValue()` (pending value if present; otherwise actual).
+   - Colors: dynamic (blue), fixed (black), pending (gray) via CSS classes.
+
+### Selection Behavior
+
+- On click:
+  - Sets `isSelected = true` locally and emits `selected(index)`.
+  - The Board manages global deselection and ensures only one cell is visually selected.
+
+### ClientCellModel Pending State
+
+`ClientCellModel` augments the shared base with `pendingCellState` and optional `notes`.
+
+- `setPending(value: number, time?: number): boolean`
+  - Validates against base rules (integers 0..9, not fixed, cooldown, effect blocks).
+  - Sets `pendingValue` and optionally a `pendingCooldownEnd` based on `time + CELL_COOLDOWN_DURATION`.
+
+- `confirmSet(value: number, time?: number): boolean`
+  - Clears pending and applies the value via `update(value, time)`.
+
+- `rejectPending(): void`
+  - Clears all pending state.
+
+- `getDisplayValue(): number`
+  - Returns `pendingValue` if available, else `value`.
+
+- `hasPending(): boolean`
+  - True when any of `pendingValue`, `pendingCooldownEnd`, or `pendingEffects` exists.
+
+### Styling & Borders
+
+- The cell uses per-edge CSS custom properties `--b-top|right|bottom|left` for borders set by the Board, defaulting to a thin gray line.
+- Selection overlay is a host `.selected` pseudo-element outline.
+- Value colors:
+  - Dynamic (default): `#1E88E5`
+  - Fixed: `#000000`
+  - Pending: `#808080`
+
+### Minimal Usage (inside a Board)
+
+```html
+<app-sudoku-cell [model]="cell(i)" [index]="i" (selected)="onCellSelected($event)"></app-sudoku-cell>
+```
+
+### Internals & Links
+
+- Component: `src/client/app/components/cell/cell.component.ts`
+- Template: `src/client/app/components/cell/cell.component.html`
+- Styles: `src/client/app/components/cell/cell.component.scss`
+- Model (client): `src/client/models/Cell.ts`
+- Model (shared base): `src/shared/models/Cell.ts`
+- Board pair: `docs/client/core/Board.md`

--- a/docs/client/core/README.md
+++ b/docs/client/core/README.md
@@ -1,0 +1,11 @@
+# Client Core
+
+Docs for client-side core building blocks.
+
+- [Board](./Board.md) — BoardModelComponent + ClientBoardModel
+- [Cell](./Cell.md) — SudokuCellComponent + ClientCellModel
+
+For broader context:
+- Game state models live under `src/shared/models`.
+- Networking/pipeline docs: `docs/pipeline/README.md`.
+- Server architecture: `docs/server/README.md`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -247,5 +247,11 @@ export default defineConfig([
     plugins: { css },
     language: "css/css",
     extends: ["css/recommended"],
+    rules: {
+      // Use the 'widely' baseline preset which includes common properties like user-select
+      "css/use-baseline": ["error", {
+        "available": "widely"
+      }]
+    }
   }
 ]);

--- a/src/client/app/app.html
+++ b/src/client/app/app.html
@@ -1,2 +1,1 @@
 <router-outlet />
-<app-network-status></app-network-status>

--- a/src/client/app/app.routes.ts
+++ b/src/client/app/app.routes.ts
@@ -1,4 +1,12 @@
+import HomePageComponent from './pages/home/home';
+import NetworkDemoPageComponent from './pages/demo/network/network.demo';
+import BoardDemoPageComponent from './pages/demo/board/board.demo';
+
 import type { Routes } from '@angular/router';
 
 
-export default [] as Routes;
+export default [
+  { path: '', component: HomePageComponent, pathMatch: 'full' },
+  { path: 'demo/board', component: BoardDemoPageComponent },
+  { path: 'demo/network', component: NetworkDemoPageComponent },
+] as Routes;

--- a/src/client/app/app.ts
+++ b/src/client/app/app.ts
@@ -5,12 +5,11 @@ import { Component } from '@angular/core';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import DynamicFaviconService from './services/dynamic-favicon.service';
-import NetworkStatusComponent from './components/network-status.component';
 
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, NetworkStatusComponent],
+  imports: [RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/src/client/app/components/board/board.component.html
+++ b/src/client/app/components/board/board.component.html
@@ -1,5 +1,5 @@
 <section class="board-wrap">
-  <div class="board" role="grid" aria-rowcount="9" aria-colcount="9">
+  <div class="board">
     @for (i of indices; track i) {
       <app-sudoku-cell
         [model]="getCellModel(i)"

--- a/src/client/app/components/board/board.component.html
+++ b/src/client/app/components/board/board.component.html
@@ -2,7 +2,7 @@
   <div class="board" role="grid" aria-rowcount="9" aria-colcount="9">
     @for (i of indices; track i) {
       <app-sudoku-cell
-        [model]="cell(i)"
+        [model]="getCellModel(i)"
         [index]="i"
         (selected)="onCellSelected($event)"
         [class.selected]="selected() === i"

--- a/src/client/app/components/board/board.component.html
+++ b/src/client/app/components/board/board.component.html
@@ -1,0 +1,12 @@
+<section class="board-wrap">
+  <div class="board" role="grid" aria-rowcount="9" aria-colcount="9">
+    @for (i of indices; track i) {
+      <app-sudoku-cell
+        [model]="cell(i)"
+        [index]="i"
+        (selected)="onCellSelected($event)"
+        [class.selected]="selected() === i"
+      ></app-sudoku-cell>
+    }
+  </div>
+</section>

--- a/src/client/app/components/board/board.component.scss
+++ b/src/client/app/components/board/board.component.scss
@@ -1,0 +1,47 @@
+.board-wrap {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  min-height: 0; /* allow children to shrink within grid container */
+}
+
+.board {
+  /* Make the board size driven by width so it stays visible even if parent height is 0.
+     Use viewport-relative limits so it fills available space without overflowing. */
+  width: min(100%, 90vmin);
+  aspect-ratio: 1;
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  grid-template-rows: repeat(9, 1fr);
+  border: 6px solid #000;
+  box-sizing: border-box;
+}
+
+/* Thick box borders */
+/* Thin default grid lines are in the cell component (via default variables).
+   Set thicker black borders on 3x3 sub-grid boundaries by assigning CSS variables
+   to the app-sudoku-cell host elements. This avoids over-specific selectors. */
+
+/* Columns 3,6: set thick right border */
+app-sudoku-cell:nth-child(9n + 3),
+app-sudoku-cell:nth-child(9n + 6) {
+  --b-right: 4px solid #000;
+}
+
+/* Columns 4,7: remove left border to avoid double thickness at box edges */
+app-sudoku-cell:nth-child(9n + 4),
+app-sudoku-cell:nth-child(9n + 7) {
+  --b-left: 0;
+}
+
+/* Rows 3,6: set thick bottom border */
+app-sudoku-cell:nth-child(n + 19):nth-child(-n + 27),
+app-sudoku-cell:nth-child(n + 46):nth-child(-n + 54) {
+  --b-bottom: 4px solid #000;
+}
+
+/* Rows 4,7: remove top border to avoid double thickness at box edges */
+app-sudoku-cell:nth-child(n + 28):nth-child(-n + 36),
+app-sudoku-cell:nth-child(n + 55):nth-child(-n + 63) {
+  --b-top: 0;
+}

--- a/src/client/app/components/board/board.component.spec.ts
+++ b/src/client/app/components/board/board.component.spec.ts
@@ -32,15 +32,14 @@ describe('BoardModelComponent', () => {
   it('emits selection and updates child selected state', () => {
     fixture.detectChanges();
     const cells = fixture.debugElement.queryAll(By.css('app-sudoku-cell'));
-    const first = cells[0].componentInstance;
     // simulate selecting the 0th cell via component API
     component.onCellSelected(0);
     fixture.detectChanges();
 
     // Check board selected signal is set
-    expect(component['selected']()).toBe(0);
-    // Child component instance should be selected
-    expect(first.isSelected).toBeTrue();
+    expect(component.selected()).toBe(0);
+    // The first child should have selected class via parent binding
+    expect(cells[0].nativeElement.classList.contains('selected')).toBeTrue();
   });
 
   it('supports seeding puzzle and marks fixed cells', () => {
@@ -48,6 +47,6 @@ describe('BoardModelComponent', () => {
     fixture.detectChanges();
 
     // After seed, model should have fixed cells for non-zero entries
-    expect(component['model'].board[0].fixed).toBeTrue();
+    expect(component.model.board[0].fixed).toBeTrue();
   });
 });

--- a/src/client/app/components/board/board.component.spec.ts
+++ b/src/client/app/components/board/board.component.spec.ts
@@ -1,0 +1,53 @@
+import { By } from '@angular/platform-browser';
+import { TestBed } from '@angular/core/testing';
+
+import SudokuCellComponent from '../cell/cell.component';
+import BoardModelComponent from './board.component';
+
+import type { ComponentFixture } from '@angular/core/testing';
+
+
+// Minimal mock puzzle generator
+const puzzle = Array.from({ length: 81 }, (_, i) => (i % 9 === 0 ? (i / 9) + 1 : 0));
+
+describe('BoardModelComponent', () => {
+  let fixture: ComponentFixture<BoardModelComponent>;
+  let component: BoardModelComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BoardModelComponent, SudokuCellComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BoardModelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders 81 cells', () => {
+    fixture.detectChanges();
+    const cells = fixture.debugElement.queryAll(By.css('app-sudoku-cell'));
+    expect(cells.length).toBe(81);
+  });
+
+  it('emits selection and updates child selected state', () => {
+    fixture.detectChanges();
+    const cells = fixture.debugElement.queryAll(By.css('app-sudoku-cell'));
+    const first = cells[0].componentInstance;
+    // simulate selecting the 0th cell via component API
+    component.onCellSelected(0);
+    fixture.detectChanges();
+
+    // Check board selected signal is set
+    expect(component['selected']()).toBe(0);
+    // Child component instance should be selected
+    expect(first.isSelected).toBeTrue();
+  });
+
+  it('supports seeding puzzle and marks fixed cells', () => {
+    component.puzzle = puzzle;
+    fixture.detectChanges();
+
+    // After seed, model should have fixed cells for non-zero entries
+    expect(component['model'].board[0].fixed).toBeTrue();
+  });
+});

--- a/src/client/app/components/board/board.component.spec.ts
+++ b/src/client/app/components/board/board.component.spec.ts
@@ -49,4 +49,97 @@ describe('BoardModelComponent', () => {
     // After seed, model should have fixed cells for non-zero entries
     expect(component.model.board[0].fixed).toBeTrue();
   });
+
+  it('seeds empty board on init when no puzzle provided', () => {
+    // fresh instance to avoid previous test side effects
+    fixture = TestBed.createComponent(BoardModelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    // Board should be initialized with 81 empty non-fixed cells
+    expect(component.model.board.length).toBe(81);
+    expect(component.model.board[0]).toBeDefined();
+    expect(component.model.board[0].value).toBe(0);
+    expect(component.model.board[0].fixed).toBeFalse();
+  });
+
+  it('puzzle setter after init re-seeds the board', () => {
+    fixture.detectChanges(); // triggers empty init
+    // Ensure an initially empty cell is not fixed
+    expect(component.model.board[0].fixed).toBeFalse();
+
+    // Now set the puzzle via the setter and verify seeding occurs
+    component.puzzle = puzzle;
+    fixture.detectChanges();
+    expect(component.model.board[0].fixed).toBeTrue();
+    // value should match provided puzzle
+    expect(component.model.board[0].value).toBe(1);
+  });
+
+  it('getCellModel fallback creates a missing cell model defensively', () => {
+    fixture.detectChanges();
+    // Simulate an unexpected missing entry
+     
+    delete component.model.board[10];
+    const m = component.getCellModel(10);
+    expect(m).toBeDefined();
+    expect(m.value).toBe(0);
+    expect(m.fixed).toBeFalse();
+  });
+
+  it('emits selectedIndexChange when a cell is selected', () => {
+    const spy = jasmine.createSpy('selectedIndexChange');
+    component.selectedIndexChange.subscribe(spy);
+    component.onCellSelected(7);
+    expect(spy).toHaveBeenCalledWith(7);
+    expect(component.selected()).toBe(7);
+  });
+
+  it('setPendingSelected returns false when no selection', () => {
+    const ok = component.setPendingSelected(5, 123);
+    expect(ok).toBeFalse();
+  });
+
+  it('setPendingSelected delegates to model when selected', () => {
+    fixture.detectChanges();
+    component.onCellSelected(5);
+    const spy = spyOn(component.model, 'setPendingCell').and.returnValue(true);
+    const now = performance.now();
+    const ok = component.setPendingSelected(9, now);
+    expect(ok).toBeTrue();
+    expect(spy).toHaveBeenCalledWith(5, 9, now);
+  });
+
+  it('confirmSelected returns false when no selection or no pending', () => {
+    expect(component.confirmSelected(performance.now())).toBeFalse();
+    // With selection but no pending value
+    fixture.detectChanges(); // ensure ngOnInit seeds board before selecting
+    component.onCellSelected(3);
+    expect(component.confirmSelected(performance.now())).toBeFalse();
+  });
+
+  it('confirmSelected delegates when pending exists', () => {
+    fixture.detectChanges();
+    const idx = 2;
+    component.onCellSelected(idx);
+    // set minimal pending state
+    component.model.board[idx].pendingCellState = { pendingValue: 4 };
+    const spy = spyOn(component.model, 'confirmCellSet').and.returnValue(true);
+    const t = performance.now();
+    const ok = component.confirmSelected(t);
+    expect(ok).toBeTrue();
+    expect(spy).toHaveBeenCalledWith(idx, 4, t);
+  });
+
+  it('rejectSelected delegates when selected and is a no-op otherwise', () => {
+    // No selection → should not throw
+    component.rejectSelected();
+
+    // With selection → delegates
+    fixture.detectChanges();
+    component.onCellSelected(8);
+    const spy = spyOn(component.model, 'rejectCellSet');
+    component.rejectSelected();
+    expect(spy).toHaveBeenCalledWith(8);
+  });
 });

--- a/src/client/app/components/board/board.component.ts
+++ b/src/client/app/components/board/board.component.ts
@@ -1,0 +1,87 @@
+import { Component, EventEmitter, Input, Output, ViewChildren, signal } from '@angular/core';
+
+import SudokuCellComponent from '../cell/cell.component';
+import ClientBoardModel from '../../../models/Board';
+
+import type { QueryList, OnInit } from '@angular/core';
+import type ClientCellModel from '../../../models/Cell';
+
+
+@Component({
+  selector: 'app-sudoku-board-model',
+  standalone: true,
+  imports: [SudokuCellComponent],
+  templateUrl: './board.component.html',
+  styleUrl: './board.component.scss'
+})
+export default class BoardModelComponent implements OnInit {
+  // Public model instance, composed here. Parent can access it via template ref if needed.
+  public readonly model = new ClientBoardModel();
+
+  @Input()
+  puzzle: ReadonlyArray<number> = [];
+  @Output()
+  selectedIndexChange = new EventEmitter<number>();
+
+  @ViewChildren(SudokuCellComponent)
+  private cellComps!: QueryList<SudokuCellComponent>;
+
+  // Flat indices 0..80 for a 9x9 board
+  readonly indices = Array.from({ length: 81 }, (_, i) => i);
+  readonly selected = signal<number | null>(null);
+
+  ngOnInit(): void {
+    if (this.puzzle.length === 81) {
+      this.seed(this.puzzle);
+    }
+  }
+
+  private seed(values: ReadonlyArray<number>): void {
+    // Initialize board with provided puzzle, marking non-zero as fixed
+    for (let i = 0; i < 81; i++) {
+      const v = values[i] ?? 0;
+      this.model.board[i] = new this.model.CellModelClass(v, v !== 0);
+    }
+  }
+
+  cell(i: number): ClientCellModel {
+    return this.model.board[i];
+  }
+
+  onCellSelected(i: number): void {
+    this.selected.set(i);
+    this.selectedIndexChange.emit(i);
+    // Visually clear other selections
+    this.cellComps?.forEach((comp, idx) => {
+      if (idx !== i) {
+        comp.deselect();
+      }
+    });
+  }
+
+  setPendingSelected(value: number, time?: number): boolean {
+    const i = this.selected();
+    if (i == null) {
+      return false;
+    }
+    return this.model.setPendingCell(i, value, time);
+  }
+  confirmSelected(time?: number): boolean {
+    const i = this.selected();
+    if (i == null) {
+      return false;
+    }
+    const pv = this.model.board[i].pendingCellState?.pendingValue;
+    if (pv === undefined) {
+      return false;
+    }
+    return this.model.confirmCellSet(i, pv, time);
+  }
+  rejectSelected(): void {
+    const i = this.selected();
+    if (i == null) {
+      return;
+    }
+    this.model.rejectCellSet(i);
+  }
+}

--- a/src/client/app/components/cell/cell.component.html
+++ b/src/client/app/components/cell/cell.component.html
@@ -1,0 +1,14 @@
+<button type="button" class="cell" (click)="onClick()" [class.fixed]="model.fixed" [class.pending]="hasPending">
+  @if (showNotes) {
+    <div class="notes" aria-hidden="true">
+      @for (n of noteGrid; track n) {
+        <span class="note">{{ noteDigit(n) }}</span>
+      }
+    </div>
+  } @else if (hasPending) {
+    <span class="v">{{ pendingValue }}</span>
+  } @else {
+    <span class="v">{{ value !== 0 ? value : '' }}</span>
+  }
+  
+</button>

--- a/src/client/app/components/cell/cell.component.html
+++ b/src/client/app/components/cell/cell.component.html
@@ -5,10 +5,7 @@
         <span class="note">{{ noteDigit(n) }}</span>
       }
     </div>
-  } @else if (hasPending) {
-    <span class="v">{{ pendingValue }}</span>
   } @else {
     <span class="v">{{ value !== 0 ? value : '' }}</span>
   }
-  
 </button>

--- a/src/client/app/components/cell/cell.component.scss
+++ b/src/client/app/components/cell/cell.component.scss
@@ -1,0 +1,76 @@
+:host {
+  display: contents;
+}
+
+.cell {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1;
+  /* Per-edge borders driven by CSS variables from the board; default to thin grey */
+  /* eslint-disable css/no-invalid-properties */
+  border-top: var(--b-top, 1px solid #9a9a9a);
+  border-right: var(--b-right, 1px solid #9a9a9a);
+  border-bottom: var(--b-bottom, 1px solid #9a9a9a);
+  border-left: var(--b-left, 1px solid #9a9a9a);
+  /* eslint-enable css/no-invalid-properties */
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* Default cell value state */
+.v {
+  /* ~50% larger while staying responsive */
+  font-size: clamp(1.5rem, 3.3vh, 2.1rem);
+  /* baseline-friendly user-select with vendor prefixes */
+  /* eslint-disable css/use-baseline */
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  /* eslint-enable css/use-baseline */
+  color: #1E88E5;
+  font-weight: 600;
+}
+
+/* Value coloring for fixed cells */
+.cell.fixed .v {
+  color: #000000;
+  font-weight: 700;
+}
+
+/* Value coloring for pending cells */
+.cell.pending .v {
+  color: #808080;
+  font-weight: 600;
+}
+
+.notes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  width: 100%;
+  height: 100%;
+  padding: 2px;
+  gap: 1px;
+  color: #b0b0b0;
+  font-size: clamp(0.9rem, 2vh, 1.4rem);
+}
+
+.note {
+  display: grid;
+  place-items: center;
+}
+
+/* Selection overlay (on host .selected) */
+:host(.selected) .cell::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border: 4px solid #1976d2;
+  pointer-events: none;
+  box-sizing: border-box;
+  z-index: 2;
+}

--- a/src/client/app/components/cell/cell.component.spec.ts
+++ b/src/client/app/components/cell/cell.component.spec.ts
@@ -56,6 +56,24 @@ describe('SudokuCellComponent', () => {
       .toContain('pending');
   });
 
+  it('noteDigit returns empty string when digit not noted', () => {
+    const m = new MockCellModel();
+    m.notes = [2, 5];
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+
+    expect(component.noteDigit(1)).toBe('');
+    expect(component.noteDigit(2)).toBe('2');
+  });
+
+  it('pendingValue getter exposes pendingCellState value', () => {
+    const m = new MockCellModel();
+    m.pendingCellState = { pendingValue: 3 };
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+    expect(component.pendingValue).toBe(3);
+  });
+
   it('renders notes grid when no value and notes present', () => {
     const m = new MockCellModel();
     m.value = 0;

--- a/src/client/app/components/cell/cell.component.spec.ts
+++ b/src/client/app/components/cell/cell.component.spec.ts
@@ -17,7 +17,7 @@ class MockCellModel {
     return !!this.pendingCellState;
   }
   getDisplayValue() {
-    return this.value;
+    return this.pendingCellState?.pendingValue ?? this.value;
   }
 }
 
@@ -84,7 +84,7 @@ describe('SudokuCellComponent', () => {
     expect(fixture.debugElement.query(By.css('.cell')).nativeElement.classList).toContain('fixed');
   });
 
-  it('emits selected and toggles selected class on click', () => {
+  it('emits selected on click', () => {
     const m = new MockCellModel();
     component.model = m as unknown as ClientCellModel;
     component.index = 42;
@@ -98,7 +98,5 @@ describe('SudokuCellComponent', () => {
     fixture.detectChanges();
 
     expect(spy).toHaveBeenCalledWith(42);
-    expect(component.isSelected).toBeTrue();
-    expect(fixture.debugElement.query(By.css(':host(.selected)'))).toBeNull();
   });
 });

--- a/src/client/app/components/cell/cell.component.spec.ts
+++ b/src/client/app/components/cell/cell.component.spec.ts
@@ -1,0 +1,104 @@
+import { By } from '@angular/platform-browser';
+import { TestBed } from '@angular/core/testing';
+
+import SudokuCellComponent from './cell.component';
+
+import type { ComponentFixture } from '@angular/core/testing';
+import type ClientCellModel from 'src/client/models/Cell';
+
+
+// Minimal mock for the ClientCellModel interface used by the component
+class MockCellModel {
+  value = 0;
+  fixed = false;
+  notes: number[] = [];
+  pendingCellState?: { pendingValue: number };
+  hasPending() {
+    return !!this.pendingCellState;
+  }
+  getDisplayValue() {
+    return this.value;
+  }
+}
+
+describe('SudokuCellComponent', () => {
+  let fixture: ComponentFixture<SudokuCellComponent>;
+  let component: SudokuCellComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SudokuCellComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SudokuCellComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders a value when present and not fixed/pending/notes', () => {
+    const m = new MockCellModel();
+    m.value = 5;
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+
+    const span = fixture.debugElement.query(By.css('.v'))!.nativeElement as HTMLElement;
+    expect(span.textContent!.trim()).toBe('5');
+  });
+
+  it('shows pending value when pending present', () => {
+    const m = new MockCellModel();
+    m.pendingCellState = { pendingValue: 7 };
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+
+    const span = fixture.debugElement.query(By.css('.v'))!.nativeElement as HTMLElement;
+    expect(span.textContent!.trim()).toBe('7');
+    expect(fixture.debugElement.query(By.css('.cell')).nativeElement.classList)
+      .toContain('pending');
+  });
+
+  it('renders notes grid when no value and notes present', () => {
+    const m = new MockCellModel();
+    m.value = 0;
+    m.notes = [1, 3, 9];
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+
+    const notes = fixture.debugElement.queryAll(By.css('.note'));
+    expect(notes.length).toBe(9);
+    // check that some notes are present at their positions
+    const texts = notes.map(n => (n.nativeElement as HTMLElement).textContent!.trim());
+    expect(texts[0]).toBe('1');
+    expect(texts[2]).toBe('3');
+    expect(texts[8]).toBe('9');
+  });
+
+  it('applies fixed styling when model.fixed is true', () => {
+    const m = new MockCellModel();
+    m.value = 4;
+    m.fixed = true;
+    component.model = m as unknown as ClientCellModel;
+    fixture.detectChanges();
+
+    // color checks cannot rely on computed styles in this unit test without rendering to browser,
+    // but we can check that the host has class 'fixed' applied
+    expect(fixture.debugElement.query(By.css('.cell')).nativeElement.classList).toContain('fixed');
+  });
+
+  it('emits selected and toggles selected class on click', () => {
+    const m = new MockCellModel();
+    component.model = m as unknown as ClientCellModel;
+    component.index = 42;
+    fixture.detectChanges();
+
+    const btn = fixture.debugElement.query(By.css('.cell'));
+    const spy = jasmine.createSpy('selected');
+    component.selected.subscribe(spy);
+
+    btn.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    expect(spy).toHaveBeenCalledWith(42);
+    expect(component.isSelected).toBeTrue();
+    expect(fixture.debugElement.query(By.css(':host(.selected)'))).toBeNull();
+  });
+});

--- a/src/client/app/components/cell/cell.component.ts
+++ b/src/client/app/components/cell/cell.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 import type ClientCellModel from '../../../models/Cell';
 
@@ -7,7 +7,8 @@ import type ClientCellModel from '../../../models/Cell';
   selector: 'app-sudoku-cell',
   standalone: true,
   templateUrl: './cell.component.html',
-  styleUrl: './cell.component.scss'
+  styleUrl: './cell.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export default class SudokuCellComponent {
   @Input({ required: true }) 
@@ -16,17 +17,15 @@ export default class SudokuCellComponent {
   index!: number;
   @Output()
   selected = new EventEmitter<number>();
-  @HostBinding('class.selected') 
-  public isSelected = false;
+  
+  readonly noteGrid: number[];
 
-  readonly noteGrid = Array.from({ length: 9 }, (_, i) => i + 1);
+  constructor() {
+    this.noteGrid = Array.from({ length: 9 }, (_, i) => i + 1);
+  }
 
   onClick(): void {
-    this.isSelected = true;
     this.selected.emit(this.index);
-  }
-  deselect(): void {
-    this.isSelected = false;
   }
 
   get hasPending(): boolean {

--- a/src/client/app/components/cell/cell.component.ts
+++ b/src/client/app/components/cell/cell.component.ts
@@ -1,0 +1,56 @@
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+
+import type ClientCellModel from '../../../models/Cell';
+
+
+@Component({
+  selector: 'app-sudoku-cell',
+  standalone: true,
+  templateUrl: './cell.component.html',
+  styleUrl: './cell.component.scss'
+})
+export default class SudokuCellComponent {
+  @Input({ required: true }) 
+  model!: ClientCellModel;
+  @Input()
+  index!: number;
+  @Output()
+  selected = new EventEmitter<number>();
+  @HostBinding('class.selected') 
+  public isSelected = false;
+
+  readonly noteGrid = Array.from({ length: 9 }, (_, i) => i + 1);
+
+  onClick(): void {
+    this.isSelected = true;
+    this.selected.emit(this.index);
+  }
+  deselect(): void {
+    this.isSelected = false;
+  }
+
+  get hasPending(): boolean {
+    return this.model.hasPending();
+  }
+
+  get showNotes(): boolean {
+    // Show notes when empty value and notes present
+    const notes = this.model.notes;
+    return this.model.value === 0 && Array.isArray(notes) && notes.length > 0;
+  }
+
+  get value(): number {
+    return this.model.getDisplayValue();
+  }
+
+  get pendingValue(): number | undefined {
+    return this.model.pendingCellState?.pendingValue;
+  }
+
+  noteDigit(digit: number): string {
+    const notes = this.model.notes;
+    const has = !!notes?.includes(digit);
+    return has ? String(digit) : '';
+  }
+
+}

--- a/src/client/app/pages/demo/board/board.demo.html
+++ b/src/client/app/pages/demo/board/board.demo.html
@@ -1,0 +1,7 @@
+<main class="demo-page">
+  <h1>Sudoku Board Model Demo</h1>
+  <app-sudoku-board-model 
+    #board [puzzle]="puzzle" 
+    (selectedIndexChange)="selected = $event"
+  ></app-sudoku-board-model>
+</main>

--- a/src/client/app/pages/demo/board/board.demo.scss
+++ b/src/client/app/pages/demo/board/board.demo.scss
@@ -1,0 +1,29 @@
+.demo-page {
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  row-gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  box-sizing: border-box;
+}
+
+.demo-page > h1 {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.demo-page app-sudoku-board-model {
+  align-self: stretch;
+  justify-self: center;
+  width: 100%;
+  max-width: 100dvw;
+  /* Prevent vertical overflow by limiting height to the available space */
+  min-height: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}

--- a/src/client/app/pages/demo/board/board.demo.ts
+++ b/src/client/app/pages/demo/board/board.demo.ts
@@ -14,19 +14,24 @@ import type { AfterViewInit } from '@angular/core';
 })
 export default class BoardDemoPageComponent implements AfterViewInit {
   @ViewChild('board', { static: true }) board!: BoardModelComponent;
-  selected: number | null = null;
+  selected: number | null;
   // Simple puzzle seed; non-zero are fixed
-  puzzle = [
-    5,3,0,0,7,0,0,0,0,
-    6,0,0,1,9,5,0,0,0,
-    0,9,8,0,0,0,0,6,0,
-    8,0,0,0,6,0,0,0,3,
-    4,0,0,8,0,3,0,0,1,
-    7,0,0,0,2,0,0,0,6,
-    0,6,0,0,0,0,2,8,0,
-    0,0,0,4,1,9,0,0,5,
-    0,0,0,0,8,0,0,7,9
-  ];
+  puzzle: number[];
+
+  constructor() {
+    this.selected = null;
+    this.puzzle = [
+      5,3,0,0,7,0,0,0,0,
+      6,0,0,1,9,5,0,0,0,
+      0,9,8,0,0,0,0,6,0,
+      8,0,0,0,6,0,0,0,3,
+      4,0,0,8,0,3,0,0,1,
+      7,0,0,0,2,0,0,0,6,
+      0,6,0,0,0,0,2,8,0,
+      0,0,0,4,1,9,0,0,5,
+      0,0,0,0,8,0,0,7,9
+    ];
+  }
 
   ngAfterViewInit(): void {
     // Showcase cells: notes (2-3), pending (2-3), dynamic placed (2-3)
@@ -56,10 +61,8 @@ export default class BoardDemoPageComponent implements AfterViewInit {
     }
 
     // Place a visible cursor at row 4, col 6 (index 42)
-    try {
-      this.board.selected.set(42);
-      this.selected = 42;
-    } catch {}
+    this.board.selected.set(42);
+    this.selected = 42;
   }
 
   randPending(): void {

--- a/src/client/app/pages/demo/board/board.demo.ts
+++ b/src/client/app/pages/demo/board/board.demo.ts
@@ -1,0 +1,78 @@
+import { Component, ViewChild } from '@angular/core';
+
+import BoardModelComponent from '../../../components/board/board.component';
+
+import type { AfterViewInit } from '@angular/core';
+
+
+@Component({
+  selector: 'app-board-demo-page',
+  standalone: true,
+  imports: [BoardModelComponent],
+  templateUrl: './board.demo.html',
+  styleUrl: './board.demo.scss'
+})
+export default class BoardDemoPageComponent implements AfterViewInit {
+  @ViewChild('board', { static: true }) board!: BoardModelComponent;
+  selected: number | null = null;
+  // Simple puzzle seed; non-zero are fixed
+  puzzle = [
+    5,3,0,0,7,0,0,0,0,
+    6,0,0,1,9,5,0,0,0,
+    0,9,8,0,0,0,0,6,0,
+    8,0,0,0,6,0,0,0,3,
+    4,0,0,8,0,3,0,0,1,
+    7,0,0,0,2,0,0,0,6,
+    0,6,0,0,0,0,2,8,0,
+    0,0,0,4,1,9,0,0,5,
+    0,0,0,0,8,0,0,7,9
+  ];
+
+  ngAfterViewInit(): void {
+    // Showcase cells: notes (2-3), pending (2-3), dynamic placed (2-3)
+    // Pick some indices that are empty in the seed puzzle
+    const notesCells = [2, 16, 74];
+    const pendingCells = [6, 28, 48];
+    const dynamicCells = [3, 24, 60];
+
+    // Notes: add candidate numbers
+    for (const i of notesCells) {
+      const cell = this.board.model.board[i];
+      cell.notes = Array.from({ length: 9 }, (_, n) => n + 1)
+        .filter(_ => Math.round(Math.random()) === 0);
+    }
+
+    // Pending: set optimistic pending values
+    for (const i of pendingCells) {
+      const v = ((i % 9) + 1);
+      this.board.model.setPendingCell(i, v, performance.now());
+    }
+
+    // Dynamic values (non-fixed): place values as if user set them
+    for (const i of dynamicCells) {
+      const v = ((i % 9) + 1);
+      // Avoid violating validation (e.g., cooldown): use update directly for demo visuals
+      this.board.model.board[i].update(v, undefined);
+    }
+
+    // Place a visible cursor at row 4, col 6 (index 42)
+    try {
+      this.board.selected.set(42);
+      this.selected = 42;
+    } catch {}
+  }
+
+  randPending(): void {
+    if (this.selected == null) {
+      return;
+    }
+    const v = (Math.random() * 9 | 0) + 1;
+    this.board.setPendingSelected(v, performance.now());
+  }
+  confirm(): void {
+    this.board.confirmSelected(performance.now());
+  }
+  reject(): void {
+    this.board.rejectSelected();
+  }
+}

--- a/src/client/app/pages/demo/network/network.demo.html
+++ b/src/client/app/pages/demo/network/network.demo.html
@@ -1,0 +1,4 @@
+<main class="demo-page">
+  <h2>Network Demo</h2>
+  <app-network-status />
+</main>

--- a/src/client/app/pages/demo/network/network.demo.scss
+++ b/src/client/app/pages/demo/network/network.demo.scss
@@ -1,0 +1,7 @@
+.demo-page {
+  min-height: 100dvh;
+  display: grid;
+  gap: 1rem;
+  place-items: center;
+  padding: 1rem;
+}

--- a/src/client/app/pages/demo/network/network.demo.ts
+++ b/src/client/app/pages/demo/network/network.demo.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+import NetworkStatusComponent from '../../../components/network-status.component';
+
+
+@Component({
+  selector: 'app-network-demo-page',
+  standalone: true,
+  imports: [NetworkStatusComponent],
+  templateUrl: './network.demo.html',
+  styleUrl: './network.demo.scss'
+})
+export default class NetworkDemoPageComponent {}

--- a/src/client/app/pages/home/home.html
+++ b/src/client/app/pages/home/home.html
@@ -1,0 +1,7 @@
+<main class="home">
+  <img src="/logo.png" alt="Evoku" class="logo">
+  <div class="actions">
+    <a routerLink="/demo/board" class="btn">Board demo</a>
+    <a routerLink="/demo/network" class="btn">Network demo</a>
+  </div>
+</main>

--- a/src/client/app/pages/home/home.scss
+++ b/src/client/app/pages/home/home.scss
@@ -1,0 +1,41 @@
+
+.home {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start; /* align items from the top */
+  padding-top: 4vh; /* reduce top padding so content sits higher */
+  gap: 0.5rem; /* tighter gap between logo and actions */
+  text-align: center;
+}
+
+.logo {
+  max-height: 60vh;
+  object-fit: contain;
+  margin: 0 auto 0.125rem auto;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  align-items: center;
+  margin-top: -0.25rem; /* smaller pull to avoid overlap while keeping buttons close */
+}
+
+.btn {
+  display: inline-block;
+  padding: 1rem 1.4rem; /* larger tap target */
+  font-size: 1.05rem; /* slightly larger text */
+  border: 1px solid #333;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #222;
+  background: #fff;
+}
+
+.btn:hover {
+  border-color: #1976d2;
+  color: #1976d2;
+}

--- a/src/client/app/pages/home/home.ts
+++ b/src/client/app/pages/home/home.ts
@@ -1,0 +1,12 @@
+import { RouterLink } from '@angular/router';
+import { Component } from '@angular/core';
+
+
+@Component({
+  selector: 'app-home-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './home.html',
+  styleUrl: './home.scss'
+})
+export default class HomePageComponent {}

--- a/src/client/app/services/network.service.ts
+++ b/src/client/app/services/network.service.ts
@@ -16,7 +16,6 @@ export default class NetworkService {
   private readonly wsService: WebSocketService;
 
   constructor(@Optional() wsService?: WebSocketService) {
-    // If Angular did not provide an instance, fall back to a manual one.
     this.wsService = wsService ?? new WebSocketService();
   }
 

--- a/src/client/globals.scss
+++ b/src/client/globals.scss
@@ -1,1 +1,8 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global resets to ensure full-viewport layouts don't scroll due to default margins */
+html, body, app-root {
+	height: 100%;
+}
+
+body {
+	margin: 0;
+}

--- a/src/client/models/Cell.ts
+++ b/src/client/models/Cell.ts
@@ -15,6 +15,7 @@ export interface IPendingCellState {
  */
 export default class ClientCellModel extends BaseCellModel {
   public pendingCellState: Partial<IPendingCellState>;
+  public notes?: number[];
 
   constructor(
     value: number = 0,
@@ -23,6 +24,7 @@ export default class ClientCellModel extends BaseCellModel {
   ) {
     super(value, fixed, effects);
     this.pendingCellState = {}; // Initialise with no pending properties
+    this.notes = undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary of Changes
### Main Features
- Implemented BoardModelComponent rendering a 9×9 grid via flat 0..80 indexing.
- Selection handling: cells emit selected(index); board tracks and visually highlights one selected cell.
- Cell rendering modes:
  - Value (default, azure blue), Pending (grey), Notes (3×3 mini-grid when value=0 with notes).
- Fixed vs Dynamic vs Pending value colors.
- Robust initialization: seeds from 81-length puzzle (non-zero → fixed) or 81 empty cells by default.
- Styling: CSS grid with thick 3×3 separators via per-edge CSS variables.

### Tests & docs
- Added unit tests: board (81 render, selection propagation, fixed seeding) and cell (value, pending, notes, fixed, selection).
- Added docs: Board.md and Cell.md (plus index README).

## References
Closes: 
- #60