### PR TITLE
Updated package.json Scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "ng build",
-    "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
-    "start:client": "npx serve -s dist/Evoku/browser -l 6942",
-    "start:server": "tsx src/server/index.ts",
+    "start": "npm run build && tsx src/server/index.ts",
     "dev": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:client": "ng serve",
     "dev:server": "tsx watch src/server/index.ts",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:client-ci": "CI=true ng test --watch=false --code-coverage",
     "test:server-ci": "jest --config jest.config.cjs --coverage",
     "lint": "npx eslint .",
-    "comp": "npx tsc -b .",
+    "comp": "npm run comp:client && npm run comp:server",
+    "comp:client": "ngc -p tsconfig.app.json --noEmit",
+    "comp:server": "tsc -p tsconfig.server.json",
     "prepare": "husky"
   },
   "private": true,

--- a/src/server/core/HTTPServer.ts
+++ b/src/server/core/HTTPServer.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import fs from 'node:fs';
 import { createServer } from 'http';
 import express from 'express';
 
@@ -22,9 +24,36 @@ export default class HTTPServer {
   }
 
   private configureRoutes(): void {
-    // Add a basic health check route for the HTTP server
-    this.app.get('/health', (req, res) => {
-      res.status(200).send('OK');
+
+    this.app.get('/health', (_req, res) => {
+      res.sendStatus(200);
+    });
+
+    this.app.get('/api', (_req, res) => {
+      res.sendStatus(501);
+    });
+
+    // Serve the built Angular client only if a build exists
+    const clientDist = path.join(process.cwd(), 'dist', 'Evoku', 'browser');
+    const clientIndex = path.join(clientDist, 'index.html');
+
+    if (fs.existsSync(clientIndex)) {
+      // Serve static files from angular build
+      // The user can choose to access the built (static) client or the development client
+      // by navigating to the appropriate port (e.g., 6942 for dev server, 8745 for this server)
+      
+      console.log(`Serving client build from ${clientDist}`);
+      this.app.use(express.static(clientDist));
+
+    } else {
+      console.warn(
+        `Warning: Client build not found at ${clientIndex}. Server will not serve the application.`
+      );
+    }
+
+    // Final 404 handler: everything else returns 404
+    this.app.use((_req, res) => {
+      res.sendStatus(404);
     });
   }
 

--- a/src/server/core/HTTPServer.ts
+++ b/src/server/core/HTTPServer.ts
@@ -37,23 +37,23 @@ export default class HTTPServer {
     const clientDist = path.join(process.cwd(), 'dist', 'Evoku', 'browser');
     const clientIndex = path.join(clientDist, 'index.html');
 
-    if (fs.existsSync(clientIndex)) {
-      // Serve static files from angular build
-      // The user can choose to access the built (static) client or the development client
-      // by navigating to the appropriate port (e.g., 6942 for dev server, 8745 for this server)
-      
-      console.log(`Serving client build from ${clientDist}`);
-      this.app.use(express.static(clientDist));
-
-    } else {
+    if (!fs.existsSync(clientIndex)) {
       console.warn(
         `Warning: Client build not found at ${clientIndex}. Server will not serve the application.`
       );
+      return
     }
 
-    // Final 404 handler: everything else returns 404
+    console.log(`Serving client build from ${clientDist}`);
+
+    // Serve static files from angular build
+    // The user can choose to access the built (static) client or the development client
+    // by navigating to the appropriate port (e.g., 6942 for dev server, 8745 for this server)
+    this.app.use(express.static(clientDist));
+
+    // Route everything back to index.html, client routing should fetch 404 if invalid
     this.app.use((_req, res) => {
-      res.sendStatus(404);
+      res.sendFile(clientIndex);
     });
   }
 


### PR DESCRIPTION
## What's Changed
- Also serves client from express if an existing build exists.
- Use res.sendStatus for other fallback routes.
- Updated `start` to first build client then runs server, also hosting the built client on a single port.
- `dev` remains split (ng serve + tsx watch), but dev server can still host built client.
- Split `comp` (tsc static typechecking) to use ngc --noEmit (client with new Angular DI) and tsc (server)