### PR TITLE
Update default fillers for demos

### DIFF
--- a/src/client/app/pages/demo/board/board.demo.html
+++ b/src/client/app/pages/demo/board/board.demo.html
@@ -1,4 +1,4 @@
-<h1>Sudoku Board Model Demo</h1>
+<h1>Resizeable Board Demo</h1>
 <div class="resizable-container">
   <app-board-model #board></app-board-model>
 </div>

--- a/src/client/app/pages/demo/board/board.demo.ts
+++ b/src/client/app/pages/demo/board/board.demo.ts
@@ -1,8 +1,6 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, type OnInit } from '@angular/core';
 
 import BoardModelComponent from '../../../components/board/board.component';
-
-import type { AfterViewInit } from '@angular/core';
 
 
 @Component({
@@ -12,54 +10,54 @@ import type { AfterViewInit } from '@angular/core';
   templateUrl: './board.demo.html',
   styleUrl: './board.demo.scss'
 })
-export default class BoardDemoPageComponent implements AfterViewInit {
-  @ViewChild('board', { static: true }) board!: BoardModelComponent;
-  // Simple puzzle seed; non-zero are fixed
+export default class BoardDemoPageComponent implements OnInit {
+  @ViewChild('board', { static: true })
+  board!: BoardModelComponent;
   puzzle: number[];
 
   constructor() {
     this.puzzle = [
-      5,3,0,0,7,0,0,0,0,
-      6,0,0,1,9,5,0,0,0,
-      0,9,8,0,0,0,0,6,0,
-      8,0,0,0,6,0,0,0,3,
-      4,0,0,8,0,3,0,0,1,
-      7,0,0,0,2,0,0,0,6,
-      0,6,0,0,0,0,2,8,0,
-      0,0,0,4,1,9,0,0,5,
-      0,0,0,0,8,0,0,7,9
+      1, 0, 7, 0, 4, 9, 2, 0, 0,
+      0, 0, 4, 2, 5, 0, 7, 3, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 1,
+      0, 0, 6, 0, 3, 2, 5, 1, 0,
+      0, 0, 0, 0, 0, 0, 8, 9, 0, 
+      5, 1, 0, 0, 0, 6, 3, 4, 2, 
+      9, 0, 1, 0, 2, 4, 6, 0, 0, 
+      3, 0, 0, 0, 9, 7, 1, 0, 0,
+      4, 7, 2, 0, 0, 3, 9, 5, 0,
     ];
   }
 
-  ngAfterViewInit(): void {
+  ngOnInit(): void {
     // Enable demo auto-accept for optimistic pending visualization
     this.board.model.autoAcceptPending = true;
-    // Load puzzle onto the pre-initialized empty board
     this.board.loadPuzzle(this.puzzle);
+
     // Showcase cells: notes (2-3), pending (2-3), dynamic placed (2-3)
-    // Pick some indices that are empty in the seed puzzle
-    const notesCells = [2, 16, 74];
-    const pendingCells = [6, 28, 48];
-    const dynamicCells = [3, 24, 60];
+    const notesCells = [
+      { idx: 75, notes: [1, 6] },
+      { idx: 76, notes: [1, 6] }
+    ];
+    const pendingCells = [{ idx: 80, value: 8 }];
+    const dynamicCells = [
+      { idx: 14, value: 1 },
+      { idx: 24, value: 4 }
+    ];
 
-    // Notes: add candidate numbers
-    for (const i of notesCells) {
-      const cell = this.board.model.board[i];
-      cell.notes = Array.from({ length: 9 }, (_, n) => n + 1)
-        .filter(_ => Math.round(Math.random()) === 0);
-    }
+    // Directly set value for dynamic placed cells so no cd effect overwrites
+    dynamicCells.forEach(c => {
+      this.board.model.board[c.idx].value = c.value;
+    });
+    // And notes
+    notesCells.forEach(c => {
+      const cell = this.board.getCellModel(c.idx);
+      cell.notes = c.notes;
+    });
 
-    // Pending: set optimistic pending values
-    for (const i of pendingCells) {
-      const v = ((i % 9) + 1);
-      this.board.model.setPendingCell(i, v, performance.now());
-    }
-
-    // Dynamic values (non-fixed): place values as if user set them
-    for (const i of dynamicCells) {
-      const v = ((i % 9) + 1);
-      // Avoid violating validation (e.g., cooldown): use update directly for demo visuals
-      this.board.model.board[i].update(v, undefined);
-    }
+    // Use the given api so as to show the cd effect dynamically.
+    pendingCells.forEach(c => {
+      this.board.model.setPendingCell(c.idx, c.value, performance.now());
+    });
   }
 }

--- a/src/client/app/pages/demo/time-attack/time-attack.demo.html
+++ b/src/client/app/pages/demo/time-attack/time-attack.demo.html
@@ -1,4 +1,4 @@
-<h1>Evoku Time Attack Gamemode Demo</h1>
+<h1>Time Attack Demo</h1>
 <div class="board-and-utilities">
   <app-board-model #board></app-board-model>
   <app-utility-buttons-holder

--- a/src/client/app/pages/demo/time-attack/time-attack.demo.ts
+++ b/src/client/app/pages/demo/time-attack/time-attack.demo.ts
@@ -1,5 +1,7 @@
-import { Component, ViewChild } from '@angular/core';
+import { getSudoku } from 'sudoku-gen';
+import { Component, ViewChild, type OnInit } from '@angular/core';
 
+import BoardConverter from '@shared/mechanics/utils/BoardConverter';
 import AppView from '../../../types/app-view';
 import ViewStateService from '../../../services/view-state.service';
 import UtilityButtonsHolderComponent 
@@ -7,8 +9,6 @@ import UtilityButtonsHolderComponent
 import NumericButtonsHolderComponent 
   from '../../../components/controls/numeric-buttons-holder/numeric-buttons-holder.component';
 import BoardModelComponent from '../../../components/board/board.component';
-
-import type { AfterViewInit } from '@angular/core';
 
 
 @Component({
@@ -22,7 +22,7 @@ import type { AfterViewInit } from '@angular/core';
   templateUrl: './time-attack.demo.html',
   styleUrl: './time-attack.demo.scss',
 })
-export default class TimeAttackDemoPageComponent implements AfterViewInit {
+export default class TimeAttackDemoPageComponent implements OnInit {
   @ViewChild('board', { static: true })
   board!: BoardModelComponent;
   puzzle: number[];
@@ -30,57 +30,14 @@ export default class TimeAttackDemoPageComponent implements AfterViewInit {
   protected AppView = AppView;
 
   constructor(protected viewStateService: ViewStateService) {
-    this.puzzle = [
-      5, 3, 0, 0, 7, 0, 0, 0, 0,
-      6, 0, 0, 1, 9, 5, 0, 0, 0,
-      0, 9, 8, 0, 0, 0, 0, 6, 0, 
-      8, 0, 0, 0, 6, 0, 0, 0, 3, 
-      4, 0, 0, 8, 0, 3, 0, 0, 1, 
-      7, 0, 0, 0, 2, 0, 0, 0, 6, 
-      0, 6, 0, 0, 0, 0, 2, 8, 0, 
-      0, 0, 0, 4, 1, 9, 0, 0, 5, 
-      0, 0, 0, 0, 8, 0, 0, 7, 9,
-    ];
+    // Let every puzzle be random for this one :D
+    this.puzzle = BoardConverter.toBoardArray(getSudoku('easy').puzzle);
   }
 
-  ngAfterViewInit(): void {
+  ngOnInit(): void {
     // Enable demo auto-accept for optimistic pending visualization (time attack sandbox)
     this.board.model.autoAcceptPending = true;
     // Load puzzle onto the pre-initialized empty board
     this.board.loadPuzzle(this.puzzle);
-    this.setupDemoBoard();
-  }
-
-  /** Sets up the board for the demo page */
-  private setupDemoBoard(): void {
-    // Showcase cells: notes (2-3), pending (2-3), dynamic placed (2-3)
-    // Pick some indices that are empty in the seed puzzle
-    const notesCells = [2, 16, 74];
-    const pendingCells = [6, 28, 48];
-    const dynamicCells = [3, 24, 60];
-
-    // Notes: add candidate numbers
-    for (const i of notesCells) {
-      const cell = this.board.model.board[i];
-      cell.notes = Array.from({ length: 9 }, (_, n) => n + 1).filter(
-        () => Math.round(Math.random()) === 0
-      );
-    }
-
-    // Pending: set optimistic pending values
-    for (const i of pendingCells) {
-      const v = (i % 9) + 1;
-      this.board.model.setPendingCell(i, v, performance.now());
-    }
-
-    // Dynamic values (non-fixed): place values as if user set them
-    for (const i of dynamicCells) {
-      const v = (i % 9) + 1;
-      // Avoid violating validation (e.g., cooldown): use update directly for demo visuals
-      this.board.model.board[i].update(v, undefined);
-    }
-
-    // Place a visible cursor at row 4, col 6 (index 42)
-    this.board.selected.set(42);
   }
 }


### PR DESCRIPTION
## Change summary
- Refactored to use ngOnInit instead of ngOnAfterView (which has the bonus effect of making everything smoother!)
- Used sudoku-gen library (clientside!) for Time Attack demo, to make each puzzle unique.
- Made Board demo always load a default puzzle with showcase (notes/pending/dynamic).